### PR TITLE
docs: fix occurred spelling in README

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -308,7 +308,7 @@ render() {
 
     const { status, notifications } = get()
     switch(status) {
-        case "Error": return html`An error has occured`;
+        case "Error": return html`An error has occurred`;
         case "Success": return html`<notification-table .notifications="${notifications}"></notification-table>`
     }
     return html`Please wait while loading`;
@@ -350,7 +350,7 @@ render() {
 
     const { status, notifications } = get()
     switch(status) {
-        case "Error": return html`An error has occured`;
+        case "Error": return html`An error has occurred`;
         case "Success": return html`<notification-table .notifications="${notifications}"></notification-table>`
     }
     return html`Please wait while loading`;
@@ -377,7 +377,7 @@ render() {
 
     const { status, notifications } = get()
     switch(status) {
-        case "Error": return html`An error has occured`;
+        case "Error": return html`An error has occurred`;
         case "Success": return html`<notification-table .notifications="${notifications}"></notification-table>`
     }
     return html`Please wait while loading`;


### PR DESCRIPTION
## Summary
- Correct three README example strings from `occured` to `occurred`
- Leave the examples otherwise unchanged

## Validation
- `rg -n "occured|occurred|An error has" readme.md`
- `git diff --check`
- `npm ci --legacy-peer-deps`
- `npm run build`

## Notes
- `npm ci` without flags is blocked by the existing `jest@30.2.0` / `ts-jest@27.0.5` peer dependency conflict in this checkout.
- `npm test -- --runInBand` is blocked by the existing Jest config requiring `jest-environment-jsdom`, which is not installed.
